### PR TITLE
updated to version 0.5.0 that uses Epsteinlib_jll v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [0.5.0] - 2025-11-XX
+
+_First public release_
+
+### Added
+- Julia wrappers: `epsteinzeta`, `epsteinzetareg` , supporting optional arguments.
+- Unit test suite for core functionality.

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "EpsteinLib"
 uuid = "a842d94e-5710-4e9e-8aa7-655017b7ad80"
 authors = ["David Gomez-Castro <david@gomezcastro.xyz>"]
-version = "0.1.0"
+version = "0.5.0"
 
 [deps]
 Epsteinlib_jll = "4ec54591-1743-56ec-8704-f258a6d96b61"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Epsteinlib_jll = ">=0.1.0"
+Epsteinlib_jll = "0.5.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I have updated Epsteinlib_jll.jl to v0.5.0 that uses epsteinlib release 0.5.0. 

The current version of Epsteinlib.jl v0.5.0 that uses exactly that version.