### PR TITLE
Configure pre-commit formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
 # ... other repos you may have
 - repo: "https://github.com/domluna/JuliaFormatter.jl"
+  rev: "v2.2.0"  # or whatever the desired release is
   hooks:
   - id: "julia-formatter"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+# ... other repos you may have
+- repo: "https://github.com/domluna/JuliaFormatter.jl"
+  hooks:
+  - id: "julia-formatter"

--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ println("Reference value:\t\t", madelung_ref)
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Please use [pre-commit](https://pre-commit.com) to ensure your commits are well-formatted by running 
+```sh
+pip install pre-commit
+pre-commit install
+```
+when you clone the repo.

--- a/src/EpsteinLib.jl
+++ b/src/EpsteinLib.jl
@@ -1,5 +1,5 @@
 module EpsteinLib
-       
+
 using Epsteinlib_jll, LinearAlgebra
 
 export epsteinzeta, epsteinzetareg
@@ -31,14 +31,14 @@ end
 
 function cleanuparguments(d, ν, A, x, y)
     ν = convert(Float64, ν)
-    if x==nothing && y==nothing && d==nothing && A==nothing
+    if x == nothing && y == nothing && d == nothing && A == nothing
         throw(ArgumentError("Either d, x, y, or A must be specified"))
     end
-    if d==nothing
-        if x!=nothing
+    if d == nothing
+        if x != nothing
             d = length(x)
         else
-            if y!=nothing
+            if y != nothing
                 d = length(y)
             else
                 d = size(A, 1)
@@ -50,7 +50,7 @@ function cleanuparguments(d, ν, A, x, y)
     if x == nothing
         x = zeros(d)
     else
-        if length(x)==d
+        if length(x) == d
             x = convert(Vector{Float64}, x)
         else
             throw(ArgumentError("Incompatible size for x"))
@@ -59,7 +59,7 @@ function cleanuparguments(d, ν, A, x, y)
     if y == nothing
         y = zeros(d)
     else
-        if length(y)==d
+        if length(y) == d
             y = convert(Vector{Float64}, y)
         else
             throw(ArgumentError("Incompatible size for y"))

--- a/src/EpsteinLib.jl
+++ b/src/EpsteinLib.jl
@@ -1,5 +1,5 @@
 module EpsteinLib
-
+       
 using Epsteinlib_jll, LinearAlgebra
 
 export epsteinzeta, epsteinzetareg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
 using Test
 using EpsteinLib
 
-  include("epstein_tests.jl")
+include("epstein_tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
 using Test
 using EpsteinLib
 
-include("epstein_tests.jl")
+  include("epstein_tests.jl")


### PR DESCRIPTION
The easiest procedure for keeping the code formatted seems to be using pre-commit hooks via the python pre-commit package. It's officially supported by JuliaFormatter.jl. 

When you try to commit unformatted code it will give an error, and format the code. Then you can commit the formatted code.

It requires a small installation step when you clone the repo that I added to the README.md

An alternative would be to have an action making suggestions in the pull-requests using [this action](https://github.com/julia-actions/julia-format). But it seems more involved.