### PR TITLE
Update CI workflow to exclude macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
         exclude:
           - os: macos-latest # Apple Silicon
             version: 'min' # Old version of julia does not run on apple silicon
-        include:
-          - os: macos-13 # Intel
-            version: 'min'
     steps:
       - uses: actions/checkout@v4
       - name: Check Project.toml


### PR DESCRIPTION
Removed macOS 13 inclusion for CI workflow. This runner is no longer supported by Github: 
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/